### PR TITLE
Bump requests version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests==2.5.1
+requests>=2.20.0
 jsonschema==2.5.1
 pytz==2014.10
 pytest==2.7.0


### PR DESCRIPTION
There is a security issue with using the earlier requests version:
CVE-2018-18074
Vulnerable versions: <= 2.19.1
Patched version: 2.20.0

The Requests package through 2.19.1 before 2018-09-14 for Python sends
an HTTP Authorization header to an http URI upon receiving a
same-hostname https-to-http redirect, which makes it easier for remote
attackers to discover credentials by sniffing the network.